### PR TITLE
feat: Allow for not verifying SSL certificates for requests

### DIFF
--- a/FuelSDK/rest.py
+++ b/FuelSDK/rest.py
@@ -323,7 +323,7 @@ class ET_GetSupport(ET_BaseObject):
 ##
 ########
 class ET_GetRest(ET_Constructor):
-    def __init__(self, auth_stub, endpoint, qs = None):
+    def __init__(self, auth_stub, endpoint, qs = None, ssl_verify = True):
         auth_stub.refresh_token()   
         fullendpoint = endpoint
         urlSeparator = '?'
@@ -332,7 +332,7 @@ class ET_GetRest(ET_Constructor):
             urlSeparator = '&'
 
         headers = {'authorization' : 'Bearer ' + auth_stub.authToken,  'user-agent' : 'FuelSDK-Python-v1.3.0'}
-        r = requests.get(fullendpoint, headers=headers)
+        r = requests.get(fullendpoint, headers=headers, verify=ssl_verify)
     
         
         self.more_results = False
@@ -346,11 +346,11 @@ class ET_GetRest(ET_Constructor):
 ##
 ########
 class ET_PostRest(ET_Constructor):  
-    def __init__(self, auth_stub, endpoint, payload):
+    def __init__(self, auth_stub, endpoint, payload, ssl_verify = True):
         auth_stub.refresh_token()
         
         headers = {'content-type' : 'application/json', 'user-agent' : 'FuelSDK-Python-v1.3.0', 'authorization' : 'Bearer ' + auth_stub.authToken}
-        r = requests.post(endpoint, data=json.dumps(payload), headers=headers)
+        r = requests.post(endpoint, data=json.dumps(payload), headers=headers, verify=ssl_verify)
         
         obj = super(ET_PostRest, self).__init__(r, True)
         return obj
@@ -361,11 +361,11 @@ class ET_PostRest(ET_Constructor):
 ##
 ########
 class ET_PatchRest(ET_Constructor):
-    def __init__(self, auth_stub, endpoint, payload):
+    def __init__(self, auth_stub, endpoint, payload, ssl_verify = True):
         auth_stub.refresh_token()
         
         headers = {'content-type' : 'application/json', 'user-agent' : 'FuelSDK-Python-v1.3.0', 'authorization' : 'Bearer ' + auth_stub.authToken}
-        r = requests.patch(endpoint , data=json.dumps(payload), headers=headers)
+        r = requests.patch(endpoint , data=json.dumps(payload), headers=headers, verify=ssl_verify)
         
         obj = super(ET_PatchRest, self).__init__(r, True)
         return obj
@@ -376,11 +376,11 @@ class ET_PatchRest(ET_Constructor):
 ##
 ########
 class ET_DeleteRest(ET_Constructor):
-    def __init__(self, auth_stub, endpoint):
+    def __init__(self, auth_stub, endpoint, ssl_verify = True):
         auth_stub.refresh_token()
 
         headers = {'authorization' : 'Bearer ' + auth_stub.authToken, 'user-agent' : 'FuelSDK-Python-v1.3.0'}
-        r = requests.delete(endpoint, headers=headers)
+        r = requests.delete(endpoint, headers=headers, verify=ssl_verify)
         
         obj = super(ET_DeleteRest, self).__init__(r, True)
         return obj

--- a/FuelSDK/unverified_https_transport.py
+++ b/FuelSDK/unverified_https_transport.py
@@ -1,0 +1,19 @@
+import urllib.request
+import ssl
+import suds.transport.http
+
+class UnverifiedHttpsTransport(suds.transport.http.HttpTransport):
+    """
+    Used with the suds client to bypass SSL certificate validation
+    """
+    
+    def __init__(self, *args, **kwargs):
+        super(UnverifiedHttpsTransport, self).__init__(*args, **kwargs)
+
+    def u2handlers(self):
+        handlers = super(UnverifiedHttpsTransport, self).u2handlers()
+        context = ssl.create_default_context()
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        handlers.append(urllib.request.HTTPSHandler(context=context))
+        return handlers

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ New Features in Version 1.3.0
   baseapiurl: <REST TENANT SPECIFIC ENDPOINT>
   soapendpoint: <SOAP TENANT SPECIFIC ENDPOINT>
   wsdl_file_local_loc: <WSDL_PATH>/ExactTargetWSDL.xml
+  ssl_verify: <True/False>
   
   [Auth Service]
   useOAuth2Authentication: True
@@ -42,6 +43,7 @@ New Features in Version 1.3.0
   applicationType: <APPLICATION_TYPE>
   redirectURI: <REDIRECT_URI_FOR_PUBLIC/WEB_APP>
   authorizationCode: <AUTHORIZATION_CODE_FOR_PUBLIC/WEB_APP>
+  ssl_verify: <True/False>
   ```
 
   Example passing config as a parameter to ET_Client constructor:
@@ -63,6 +65,7 @@ New Features in Version 1.3.0
         'applicationType': '<APPLICATION_TYPE>'
         'redirectURI': '<REDIRECT_URI_FOR_PUBLIC/WEB_APP>'
         'authorizationCode': '<AUTHORIZATION_CODE_FOR_PUBLIC/WEB_APP>'
+        'ssl_verify': <True/False>
     })
   ```
   
@@ -86,11 +89,13 @@ New Features in Version 1.2.0
   baseapiurl: <REST TENANT SPECIFIC ENDPOINT>
   soapendpoint: <SOAP TENANT SPECIFIC ENDPOINT>
   wsdl_file_local_loc: <WSDL_PATH>/ExactTargetWSDL.xml
+  ssl_verify: <True/False>
   
   [Auth Service]
   useOAuth2Authentication: True
   accountId: <TARGET_ACCOUNT_ID>
   scope: <PERMISSION_LIST>
+  ssl_verify: <True/False>
   ```
   
   Example passing config as a parameter to ET_Client constructor:
@@ -108,7 +113,8 @@ New Features in Version 1.2.0
         'wsdl_file_local_loc': r'<WSDL_PATH>/ExactTargetWSDL.xml',
         'useOAuth2Authentication': 'True',
         'accountId': '<TARGET_ACCOUNT_ID>',
-        'scope': '<PERMISSION_LIST>'
+        'scope': '<PERMISSION_LIST>',
+        'ssl_verify': 'False'
     })
   ```
 


### PR DESCRIPTION
Many corporate networks use SSL decryption of requests for security purposes akin to a man in the middle attack.  This decryption causes underlying frameworks to throw SSL exceptions.  It would be nice to provide an option to allow users to disable certificate verification of requests.